### PR TITLE
Add pytest tests and config loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.Python

--- a/config/sentinel_config.toml
+++ b/config/sentinel_config.toml
@@ -1,0 +1,4 @@
+# Example configuration file
+[watchlist]
+processes = ['node', 'chrome', 'WindowServer']
+threshold_mb = 4096

--- a/python/config_loader.py
+++ b/python/config_loader.py
@@ -1,0 +1,11 @@
+import tomllib
+from pathlib import Path
+
+
+DEFAULT_CONFIG_PATH = Path(__file__).resolve().parent.parent / 'config' / 'sentinel_config.toml'
+
+
+def load_config(path: Path = DEFAULT_CONFIG_PATH) -> dict:
+    """Load TOML configuration from the given path."""
+    with open(path, 'rb') as f:
+        return tomllib.load(f)

--- a/python/gui_tk.py
+++ b/python/gui_tk.py
@@ -1,0 +1,9 @@
+# Basic Tkinter GUI placeholder
+
+import tkinter as tk
+
+root = tk.Tk()
+root.title('Sentinel GUI')
+label = tk.Label(root, text='Sentinel Memory Watcher')
+label.pack()
+root.mainloop()

--- a/python/main.py
+++ b/python/main.py
@@ -1,0 +1,4 @@
+# Sentinel Memory Watcher - Python Version
+
+if __name__ == '__main__':
+    print('Sentinel Python CLI running...')

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -1,0 +1,2 @@
+psutil
+rich

--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,3 @@
+# Sentinel - Rust Core
+
+To be used with Tauri shell.

--- a/tauri-shell/README.md
+++ b/tauri-shell/README.md
@@ -1,0 +1,3 @@
+# Tauri Shell (Placeholder)
+
+This will be the GUI host for the Rust CLI core.

--- a/tests/test_config_loader.py
+++ b/tests/test_config_loader.py
@@ -1,0 +1,24 @@
+import sys
+import pathlib
+from pathlib import Path
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from python.config_loader import load_config, DEFAULT_CONFIG_PATH
+
+
+def test_load_config_default():
+    config = load_config()
+    assert 'watchlist' in config
+    assert config['watchlist']['threshold_mb'] == 4096
+    assert 'node' in config['watchlist']['processes']
+
+
+def test_load_config_custom(tmp_path):
+    custom_path = tmp_path / 'cfg.toml'
+    custom_path.write_text('[watchlist]\nprocesses=["a"]\nthreshold_mb=1')
+    config = load_config(custom_path)
+    assert config['watchlist']['processes'] == ['a']
+    assert config['watchlist']['threshold_mb'] == 1

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,11 @@
+import subprocess
+import sys
+import os
+
+
+def test_main_output():
+    result = subprocess.check_output(
+        [sys.executable, os.path.join('python', 'main.py')],
+        text=True,
+    )
+    assert result.strip() == 'Sentinel Python CLI running...'


### PR DESCRIPTION
## Summary
- introduce `config_loader` to parse sentinel_config.toml
- add tests for CLI output and config loader
- ignore `__pycache__` files

## Testing
- `pytest -q`
- `python3 python/main.py`


------
https://chatgpt.com/codex/tasks/task_e_688034a218f08323873791a5e01a2722